### PR TITLE
Fix wrong params type for subject page

### DIFF
--- a/src/app/[subject]/page.tsx
+++ b/src/app/[subject]/page.tsx
@@ -10,9 +10,9 @@ import { SEOProvider } from '../../../contexts/SEOContext'
 export const revalidate = 60;
 
 interface SubjectPageProps {
-  params: Promise<{
+  params: {
     subject: string
-  }>
+  }
 }
 
 async function getHeaderData(): Promise<HeaderData | undefined> {
@@ -62,7 +62,7 @@ export async function generateStaticParams() {
 
 export async function generateMetadata({ params }: SubjectPageProps): Promise<Metadata> {
   try {
-  const { subject } = await params
+  const { subject } = params
   const subjectPageData = await getSubjectPageData(subject)
   
   if (!subjectPageData) {
@@ -95,7 +95,7 @@ export async function generateMetadata({ params }: SubjectPageProps): Promise<Me
 }
 
 export default async function SubjectPage({ params }: SubjectPageProps) {
-  const { subject } = await params
+  const { subject } = params
   const headerData = await getHeaderData()
   const footerData = await getFooterData()
   const subjectPageData = await getSubjectPageData(subject)


### PR DESCRIPTION
## Summary
- correct `SubjectPageProps` params type and usage

## Testing
- `npm run lint`
- `npm run build` *(fails: Next.js couldn't fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_684182ff652883308043e8583d37cce3